### PR TITLE
Fix Issue 3020256: Null pointer on missing variation

### DIFF
--- a/commerce_google_tag_manager.module
+++ b/commerce_google_tag_manager.module
@@ -34,8 +34,12 @@ function commerce_google_tag_manager_commerce_product_view(&$build) {
   if (Drupal::request()->getMethod() === 'GET' && $build['#view_mode'] === 'full') {
     /** @var \Drupal\commerce_product\Entity\ProductInterface $product */
     $product = $build['#commerce_product'];
-    /** @var \Drupal\commerce_google_tag_manager\EventTrackerService $event_tracker */
-    $event_tracker = Drupal::service('commerce_google_tag_manager.event_tracker');
-    $event_tracker->productDetailViews([$product->getDefaultVariation()]);
+    $default_variation = $product->getDefaultVariation();
+
+    if ($default_variation) {
+      /** @var \Drupal\commerce_google_tag_manager\EventTrackerService $event_tracker */
+      $event_tracker = Drupal::service('commerce_google_tag_manager.event_tracker');
+      $event_tracker->productDetailViews([$default_variation]);
+    }
   }
 }

--- a/tests/src/Functional/ProductDetailViewsTest.php
+++ b/tests/src/Functional/ProductDetailViewsTest.php
@@ -105,7 +105,7 @@ class ProductDetailViewsTest extends CommerceBrowserTestBase {
     $this->assertResponse(200);
 
     $events = $this->tempStore->get('events');
-    $this->assertSame([], $events);
+    $this->assertNull($events);
   }
 
 }

--- a/tests/src/Functional/ProductDetailViewsTest.php
+++ b/tests/src/Functional/ProductDetailViewsTest.php
@@ -17,7 +17,14 @@ use Drupal\commerce_product\Entity\ProductVariation;
 class ProductDetailViewsTest extends CommerceBrowserTestBase {
 
   /**
-   * The product to test againts.
+   * The temp store holding the Enhanced Ecommerce event data.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  private $tempStore;
+
+  /**
+   * The product to test against.
    *
    * @var \Drupal\commerce_product\Entity\
    */
@@ -38,6 +45,19 @@ class ProductDetailViewsTest extends CommerceBrowserTestBase {
   protected function setUp() {
     parent::setUp();
 
+    $this->tempStore = $this->container->get('tempstore.private')->get('commerce_google_tag_manager');
+
+    $this->product = Product::create([
+      'type'  => 'default',
+      'title' => 'Lorem Ipsum',
+    ]);
+    $this->product->save();
+  }
+
+  /**
+   * Cover commerce_google_tag_manager_commerce_product_view.
+   */
+  public function testProductDetailViews() {
     $variation = ProductVariation::create([
       'type'   => 'default',
       'sku'    => 'lorem-ipsum-120',
@@ -46,20 +66,7 @@ class ProductDetailViewsTest extends CommerceBrowserTestBase {
       'status' => TRUE,
     ]);
 
-    $this->product = Product::create([
-      'type'  => 'default',
-      'title' => 'Lorem Ipsum',
-    ]);
-    $this->product->save();
     $this->product->addVariation($variation)->save();
-
-  }
-
-  /**
-   * Cover commerce_google_tag_manager_commerce_product_view.
-   */
-  public function testProductDetailViews() {
-    $this->tempStore = $this->container->get('tempstore.private')->get('commerce_google_tag_manager');
 
     $this->drupalGet($this->product->toUrl()->toString());
     $this->assertResponse(200);
@@ -85,6 +92,20 @@ class ProductDetailViewsTest extends CommerceBrowserTestBase {
         ],
       ],
     ], $events);
+  }
+
+  /**
+   * Cover commerce_google_tag_manager_commerce_product_view.
+   *
+   * Test that the module does not track the productDetailViews event if
+   * no default variation exists.
+   */
+  public function testMissingDefaultVariation() {
+    $this->drupalGet($this->product->toUrl()->toString());
+    $this->assertResponse(200);
+
+    $events = $this->tempStore->get('events');
+    $this->assertSame([], $events);
   }
 
 }


### PR DESCRIPTION
This pull request adds the patch submitted by archnode and a test case. See https://www.drupal.org/project/commerce_google_tag_manager/issues/3020256