### PR TITLE
Issue #3056876 by eiriksm: Remove deprecated calls to ::assertResponse in tests

### DIFF
--- a/tests/src/Functional/EventsControllerTest.php
+++ b/tests/src/Functional/EventsControllerTest.php
@@ -72,12 +72,12 @@ class EventsControllerTest extends CommerceBrowserTestBase {
   public function testGetEvents() {
     // Go to a product page to fire a EVENT_PRODUCT_DETAIL_VIEWS event.
     $this->drupalGet($this->product->toUrl()->toString());
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     // Assert the previous event has been stored.
     $url = Url::fromRoute('commerce_google_tag_manager.events');
     $content = $this->drupalGet($url);
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
     $this->assertSame('[{"event":"productDetailViews","ecommerce":{"detail":{"actionField":{"list":""},"products":[{"name":"Lorem Ipsum","id":"1","price":"120.00","variant":"Lorem Ipsum"}]}}}]', (string) $content);
 
     // Assert stored events are flush after first fetch.

--- a/tests/src/Functional/ProductDetailViewsTest.php
+++ b/tests/src/Functional/ProductDetailViewsTest.php
@@ -69,7 +69,7 @@ class ProductDetailViewsTest extends CommerceBrowserTestBase {
     $this->product->addVariation($variation)->save();
 
     $this->drupalGet($this->product->toUrl()->toString());
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     $events = $this->tempStore->get('events');
     $this->assertSame([
@@ -102,7 +102,7 @@ class ProductDetailViewsTest extends CommerceBrowserTestBase {
    */
   public function testMissingDefaultVariation() {
     $this->drupalGet($this->product->toUrl()->toString());
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     $events = $this->tempStore->get('events');
     $this->assertNull($events);


### PR DESCRIPTION
https://www.drupal.org/project/commerce_google_tag_manager/issues/3056876